### PR TITLE
Add partial support for images

### DIFF
--- a/public/background.js
+++ b/public/background.js
@@ -25,6 +25,17 @@ const INITIAL_APP_DATA = [
   },
 ];
 
+function createSnippet(contentType, contentData) {
+  const timestamp = new Date();
+
+  return {
+    id: timestamp.getTime(),
+    content_type: contentType,
+    content_data: contentData,
+    created_at: timestamp.toISOString(),
+  };
+}
+
 chrome.runtime.onInstalled.addListener(async () => {
   chrome.storage.local.set({ appData: INITIAL_APP_DATA });
 
@@ -38,4 +49,20 @@ chrome.runtime.onInstalled.addListener(async () => {
       files: ["content-script.js"],
     });
   }
+});
+
+chrome.contextMenus.create({
+  id: "clippy-copy-image",
+  title: "Copy Image with clippy",
+  contexts: ["image"],
+});
+
+chrome.contextMenus.onClicked.addListener(async (info) => {
+  const snippet = createSnippet("image/png", info.srcUrl);
+
+  chrome.storage.local.get("appData", (result) => {
+    const appData = [snippet, ...result.appData];
+
+    chrome.storage.local.set({ appData });
+  });
 });

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,7 +3,7 @@
   "name": "clippy - Gboard clipboard for Chrome",
   "version": "0.0.1",
   "manifest_version": 3,
-  "permissions": ["scripting", "storage", "tabs"],
+  "permissions": ["contextMenus", "scripting", "storage", "tabs", "unlimitedStorage"],
   "host_permissions": ["http://*/*", "https://*/*"],
   "action": {
     "default_popup": "index.html",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Snippet } from "./common/types";
+import { Image, PlainText } from "./components";
 import { getAppData, setAppData } from "./utils";
 
 function App() {
@@ -16,10 +17,6 @@ function App() {
     });
   };
 
-  const copySnippet = async (snippet: string) => {
-    await navigator.clipboard.writeText(snippet);
-  };
-
   useEffect(() => {
     initializeApp();
   }, []);
@@ -30,15 +27,13 @@ function App() {
         Recent
       </h6>
       <div className="grid grid-cols-2 items-start gap-2.5">
-        {snippets.map((snippet, index) => (
-          <div
-            key={snippet.id}
-            onClick={() => copySnippet(snippet.content_data)}
-            className="rounded-md p-2.5 bg-white hover:bg-slate-50 text-sm cursor-pointer select-none"
-          >
-            {snippet.content_data}
-          </div>
-        ))}
+        {snippets.map((snippet, index) =>
+          snippet.content_type === "text/plain" ? (
+            <PlainText contentText={snippet.content_data} />
+          ) : (
+            <Image contentUrl={snippet.content_data} />
+          )
+        )}
       </div>
     </div>
   );

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,3 +1,11 @@
+export interface ImageProps {
+  contentUrl: string;
+}
+
+export interface PlainTextProps {
+  contentText: string;
+}
+
 export interface Snippet {
   id: string;
   created_at: string;

--- a/src/components/Image.tsx
+++ b/src/components/Image.tsx
@@ -1,10 +1,17 @@
 import React from "react";
 import { ImageProps } from "../common/types";
+import { getBlobFromUrl } from "../utils";
 
 function Image(props: ImageProps) {
   const { contentUrl } = props;
 
   const handleClick = async () => {
+    const blob = await getBlobFromUrl(contentUrl);
+    const clipboardItem = new ClipboardItem({
+      ["image/png"]: blob.slice(0, blob.size, "image/png"),
+    });
+
+    navigator.clipboard.write([clipboardItem]);
   };
 
   return (

--- a/src/components/Image.tsx
+++ b/src/components/Image.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { ImageProps } from "../common/types";
+
+function Image(props: ImageProps) {
+  const { contentUrl } = props;
+
+  const handleClick = async () => {
+  };
+
+  return (
+    <div
+      onClick={handleClick}
+      className="overflow-hidden rounded-md bg-white hover:bg-slate-50 text-sm cursor-pointer select-none"
+    >
+      <img src={contentUrl} className="object-cover" />
+    </div>
+  );
+}
+
+export default Image;

--- a/src/components/PlainText.tsx
+++ b/src/components/PlainText.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { PlainTextProps } from "../common/types";
+
+export function PlainText(props: PlainTextProps) {
+  const { contentText } = props;
+  
+  const handleClick = () => {
+    navigator.clipboard.writeText(contentText);
+  };
+
+  return (
+    <div
+      onClick={handleClick}
+      className="rounded-md p-2.5 bg-white hover:bg-slate-50 text-sm cursor-pointer select-none"
+    >
+      {contentText}
+    </div>
+  );
+}
+
+export default PlainText;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,2 @@
+export { default as Image } from './Image';
+export { default as PlainText } from './PlainText';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -11,3 +11,8 @@ export function getAppData(): Promise<Snippet[]> {
 export function setAppData(appData: Snippet[]) {
   chrome.storage.local.set({ appData });
 }
+
+export async function getBlobFromUrl(url: string) {
+  const response = await fetch(url);
+  return response.blob();
+}


### PR DESCRIPTION
### ✏️ Changes

- Added context menu for copying image to clipboard
- Added Image component
- Implemented click image snippet to copy as PNG


### 📺 Demo

Context Menu:
![image](https://user-images.githubusercontent.com/11486217/157363004-5611ef11-0e96-489f-8428-5eab70d2b8b8.png)

Pop-up:
![image](https://user-images.githubusercontent.com/11486217/157363154-c7b54e6b-9083-4a0d-8fea-0f6b6421ffa4.png)
